### PR TITLE
Citation patch

### DIFF
--- a/Inetpub/wwwroot/cgi-bin/cdr/CiteSearch.py
+++ b/Inetpub/wwwroot/cgi-bin/cdr/CiteSearch.py
@@ -6,6 +6,7 @@
 # JIRA::OCECDR-3456
 # JIRA::OCECDR-4201
 # JIRA::OCECDR-4434
+# JIRA::OCECDR-4463
 #----------------------------------------------------------------------
 import cgi, cdr, cdrcgi, cdrdb, requests, sys, lxml.etree as etree
 
@@ -120,7 +121,7 @@ def getPubmedArticle(doc):
 #----------------------------------------------------------------------
 def getArticleTitle(article):
     for node in article.findall("MedlineCitation/Article/ArticleTitle"):
-        return node.text
+        return cdr.get_text(node)
 
 #----------------------------------------------------------------------
 # Retrieve an XML document for a Pubmed article from NLM.

--- a/Inetpub/wwwroot/cgi-bin/cdr/CiteSearch.py
+++ b/Inetpub/wwwroot/cgi-bin/cdr/CiteSearch.py
@@ -5,6 +5,7 @@
 # BZIssue::5174
 # JIRA::OCECDR-3456
 # JIRA::OCECDR-4201
+# JIRA::OCECDR-4434
 #----------------------------------------------------------------------
 import cgi, cdr, cdrcgi, cdrdb, requests, sys, lxml.etree as etree
 
@@ -103,6 +104,15 @@ def getPubmedArticle(doc):
         cdrcgi.bail("unable to parse document from NLM")
     for node in tree.findall("PubmedArticle"):
         etree.strip_elements(node, "CommentsCorrectionsList")
+        namespace = "http://www.w3.org/1998/Math/MathML"
+        mml_math = "{{{}}}math".format(namespace)
+        namespaces = dict(mml=namespace)
+        for child in node.xpath("//mml:math", namespaces=namespaces):
+            if child.tail is None:
+                child.tail = "[formula]"
+            else:
+                child.tail = "[formula]" + child.tail
+        etree.strip_elements(node, mml_math, with_tail=False)
         return node
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
This was deployed to production on Wednesday, 2018-05-18

Addresses:
OCECDR-4434 (avoid breakage by NLM DTD change)
OCECDR-4463 (prevent title markup from blocking citation import)

@venglisch is probably not available to review this, @blairlearn, so I've included you.